### PR TITLE
chore: Refactor test cases and update alloy dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ keywords = ["alloy", "ethereum", "solidity", "rust", "uniswap"]
 include = ["src/**/*.rs"]
 
 [dependencies]
-alloy = { version = "0.2.0", features = ["contract", "provider-http"] }
+alloy = { version = "0.2.0", features = ["contract", "transports"] }
 anyhow = "1"
-once_cell = "1.19"
 
 [dev-dependencies]
+alloy = { version = "0.2.0", features = ["rpc-types", "transport-http"] }
 dotenv = "0.15.0"
 futures = "0.3"
-tokio = { version = "1.37", features = ["full"] }
+once_cell = "1.19"
+tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Aperture-Lens
+# Uniswap-Lens
 
-[![Foundry](https://github.com/Aperture-Finance/Aperture-Lens/actions/workflows/foundry.yml/badge.svg)](https://github.com/Aperture-Finance/Aperture-Lens/actions/workflows/foundry.yml)
-[![Node.js](https://github.com/Aperture-Finance/Aperture-Lens/actions/workflows/nodejs.yml/badge.svg)](https://github.com/Aperture-Finance/Aperture-Lens/actions/workflows/nodejs.yml)
-[![Rust](https://github.com/Aperture-Finance/Aperture-Lens/actions/workflows/rust.yml/badge.svg)](https://github.com/Aperture-Finance/Aperture-Lens/actions/workflows/rust.yml)
+[![Foundry](https://github.com/shuhuiluo/uniswap-lens-rs/actions/workflows/foundry.yml/badge.svg)](https://github.com/shuhuiluo/uniswap-lens-rs/actions/workflows/foundry.yml)
+[![Node.js](https://github.com/shuhuiluo/uniswap-lens-rs/actions/workflows/nodejs.yml/badge.svg)](https://github.com/shuhuiluo/uniswap-lens-rs/actions/workflows/nodejs.yml)
+[![Rust](https://github.com/shuhuiluo/uniswap-lens-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/shuhuiluo/uniswap-lens-rs/actions/workflows/rust.yml)
 
 [![npm version](https://img.shields.io/npm/v/aperture-lens/latest.svg)](https://www.npmjs.com/package/aperture-lens/v/latest)
-[![crates.io](https://img.shields.io/crates/v/aperture-lens.svg)](https://crates.io/crates/aperture-lens)
+[![crates.io](https://img.shields.io/crates/v/uniswap-lens.svg)](https://crates.io/crates/uniswap-lens)
 
 Contains ephemeral lens contracts that can be called without deployment and their interfaces in various Web3 libraries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,19 @@
+//! # uniswap-lens
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    unreachable_pub,
+    clippy::missing_const_for_fn,
+    rustdoc::all
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+#[allow(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    clippy::missing_const_for_fn
+)]
 pub mod bindings;
 pub mod caller;
 pub mod pool_lens;


### PR DESCRIPTION
The commit includes code refactoring in tests of `src/pool_lens.rs` to avoid repeating the provider creation. The provider is created using a Lazy static variable. A previously commented out test case `test_get_positions_slots` is enabled and updated. The alloy library feature 'transports' is added in dependencies, replacing 'provider-http'. Some rust warning settings are also added to `lib.rs`. The project is renamed from 'Aperture-Lens' to 'Uniswap-Lens'.