### PR TITLE
perf: upgrade Solidity version and disable CBOR metadata

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,7 @@ cache = true
 optimizer = true
 optimizer_runs = 4294967295
 bytecode_hash = 'none'
+cbor_metadata = false
 sparse_mode = true
 ignored_error_codes = [3860, 5574]
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ import { SolidityUserConfig } from "hardhat/types/config";
  */
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.22",
+    version: "0.8.26",
     settings: {
       optimizer: {
         enabled: true,
@@ -18,6 +18,7 @@ const config: HardhatUserConfig = {
       viaIR: true,
       evmVersion: "paris",
       metadata: {
+        appendCBOR: false,
         bytecodeHash: "none",
       },
     },


### PR DESCRIPTION
Updated the Solidity compiler version to 0.8.26 in the Hardhat configuration. Disabled the appendCBOR metadata option in both Hardhat and Foundry settings to streamline metadata handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option `cbor_metadata` to enhance metadata handling.
	- Updated Solidity compiler version to 0.8.26 for improved performance and security.
	- Added setting `metadata.appendCBOR` to streamline metadata output.

- **Bug Fixes**
	- Adjustments may improve compatibility with tools expecting different metadata formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->