### PR TITLE
fix(clippy): Add #[inline] annotations and minor refactoring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 //! # uniswap-lens
 //!
 //! A library for querying Uniswap V3 using ephemeral lens contracts.
+
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
     unreachable_pub,
     clippy::missing_const_for_fn,
+    clippy::missing_inline_in_public_items,
     clippy::redundant_clone,
     rustdoc::all
 )]
@@ -15,11 +17,7 @@
 
 extern crate alloc;
 
-#[allow(
-    missing_copy_implementations,
-    missing_debug_implementations,
-    clippy::missing_const_for_fn
-)]
+#[allow(warnings)]
 pub mod bindings;
 pub mod caller;
 pub mod pool_lens;

--- a/src/pool_lens.rs
+++ b/src/pool_lens.rs
@@ -47,6 +47,7 @@ use anyhow::Result;
 /// ## Returns
 ///
 /// A vector of populated ticks within the range
+#[inline]
 pub async fn get_populated_ticks_in_range<T, P>(
     pool: Address,
     tick_lower: I24,
@@ -97,6 +98,7 @@ macro_rules! get_pool_storage {
 /// ## Returns
 ///
 /// A vector of slots containing the storage data
+#[inline]
 pub async fn get_static_slots<T, P>(
     pool: Address,
     provider: P,
@@ -125,6 +127,7 @@ where
 /// ## Returns
 ///
 /// A vector of slots containing the storage data
+#[inline]
 pub async fn get_ticks_slots<T, P>(
     pool: Address,
     tick_lower: I24,
@@ -152,6 +155,7 @@ where
 /// ## Returns
 ///
 /// A vector of slots containing the storage data
+#[inline]
 pub async fn get_tick_bitmap_slots<T, P>(
     pool: Address,
     provider: P,
@@ -178,6 +182,7 @@ where
 /// ## Returns
 ///
 /// A vector of slots containing the storage data
+#[inline]
 pub async fn get_positions_slots<T, P>(
     pool: Address,
     positions: Vec<PositionKey>,

--- a/src/position_lens.rs
+++ b/src/position_lens.rs
@@ -48,6 +48,7 @@ use anyhow::Result;
 /// ## Returns
 ///
 /// The position details
+#[inline]
 pub async fn get_position_details<T, P>(
     npm: Address,
     token_id: U256,
@@ -77,6 +78,7 @@ where
 /// ## Returns
 ///
 /// The array of position details
+#[inline]
 pub async fn get_positions<T, P>(
     npm: Address,
     token_ids: Vec<U256>,
@@ -106,6 +108,7 @@ where
 /// ## Returns
 ///
 /// The array of position details
+#[inline]
 pub async fn get_all_positions_by_owner<T, P>(
     npm: Address,
     owner: Address,
@@ -274,7 +277,7 @@ mod tests {
         let provider = PROVIDER.clone();
         let _positions = get_positions(
             NPM_ADDRESS,
-            (1u64..100)
+            (1_u64..100)
                 .map(|i| U256::from_limbs([i, 0, 0, 0]))
                 .collect(),
             provider.clone(),

--- a/src/storage_lens.rs
+++ b/src/storage_lens.rs
@@ -9,7 +9,7 @@ use crate::bindings::ephemeralstoragelens::{
 use alloc::vec::Vec;
 use alloy::{
     eips::BlockId,
-    primitives::{Address, FixedBytes},
+    primitives::{Address, B256},
     providers::Provider,
     rpc::types::state::{AccountOverride, StateOverride},
     transports::Transport,
@@ -26,13 +26,16 @@ use anyhow::Result;
 /// * `provider`: The alloy provider
 /// * `block_id`: Optional block id to query
 ///
-/// returns: Result<Vec<[u8; 32], Global>, ContractError<M>>
+/// ## Returns
+///
+/// The storage values at the given slots
+#[inline]
 pub async fn get_storage_at<T, P>(
     address: Address,
-    slots: Vec<FixedBytes<32>>,
+    slots: Vec<B256>,
     provider: P,
     block_id: Option<BlockId>,
-) -> Result<Vec<FixedBytes<32>>>
+) -> Result<Vec<B256>>
 where
     T: Transport + Clone,
     P: Provider<T>,
@@ -71,7 +74,7 @@ mod tests {
         let slots = get_storage_at(
             POOL_ADDRESS,
             (0..10)
-                .map(|i| FixedBytes::from(U256::from_limbs([i, 0, 0, 0])))
+                .map(|i| B256::from(U256::from_limbs([i, 0, 0, 0])))
                 .collect(),
             provider.clone(),
             Some(BLOCK_NUMBER),


### PR DESCRIPTION
Add #[inline] annotations to improve inlining for frequently used functions in pool_lens.rs, position_lens.rs, and storage_lens.rs. Refactor warnings configuration and minor syntactic adjustments in src/lib.rs and other files for better code readability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added performance optimizations by introducing the `#[inline]` attribute to several asynchronous functions, enhancing execution speed.
	- Updated data handling in the `get_storage_at` function for improved compatibility with 256-bit representations.

- **Bug Fixes**
	- Improved readability in the test module with minor syntax adjustments.

- **Chores**
	- Updated test cases to align with new data type expectations in the storage handling functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->