### PR TITLE
feat(error): Add custom error handling to improve robustness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ include = ["src/**/*.rs"]
 [dependencies]
 alloy = { version = "0.3", features = ["contract", "rpc-types"] }
 anyhow = "1"
+thiserror = { version = "1.0", optional = true }
 
 [features]
 default = []
-std = ["alloy/std"]
+std = ["alloy/std", "thiserror"]
 
 [dev-dependencies]
 alloy = { version = "0.3", features = ["transport-http"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,31 @@
+use alloy::{contract::Error as ContractError, sol_types::Error as AbiError};
+
+#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+pub enum Error {
+    /// An error occurred retrieving the revert data.
+    #[cfg_attr(feature = "std", error("Invalid revert data"))]
+    InvalidRevertData,
+
+    /// An error occurred ABI encoding or decoding.
+    #[cfg_attr(feature = "std", error("{0}"))]
+    AbiError(AbiError),
+
+    /// An error occurred interacting with a contract over RPC.
+    #[cfg_attr(feature = "std", error("{0}"))]
+    ContractError(ContractError),
+}
+
+impl From<AbiError> for Error {
+    #[inline]
+    fn from(e: AbiError) -> Self {
+        Self::AbiError(e)
+    }
+}
+
+impl From<ContractError> for Error {
+    #[inline]
+    fn from(e: ContractError) -> Self {
+        Self::ContractError(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate alloc;
 #[allow(warnings)]
 pub mod bindings;
 pub mod caller;
+pub mod error;
 pub mod pool_lens;
 pub mod position_lens;
 pub mod storage_lens;
@@ -28,5 +29,5 @@ pub mod storage_lens;
 mod tests;
 
 pub mod prelude {
-    pub use super::{bindings::*, pool_lens::*, position_lens::*, storage_lens::*};
+    pub use super::{error::Error, pool_lens::*, position_lens::*, storage_lens::*};
 }

--- a/src/storage_lens.rs
+++ b/src/storage_lens.rs
@@ -3,9 +3,7 @@
 //! The storage lens module provides a function to batch `eth_getStorageAt` RPC calls in a single
 //! `eth_call` by overriding the target contract's deployed bytecode with `EphemeralStorageLens`.
 
-use crate::bindings::ephemeralstoragelens::{
-    EphemeralStorageLens, EphemeralStorageLens::EphemeralStorageLensInstance,
-};
+use crate::{bindings::ephemeralstoragelens::EphemeralStorageLens, error::Error};
 use alloc::vec::Vec;
 use alloy::{
     eips::BlockId,
@@ -14,7 +12,6 @@ use alloy::{
     rpc::types::state::{AccountOverride, StateOverride},
     transports::Transport,
 };
-use anyhow::Result;
 
 /// Batch `eth_getStorageAt` RPC calls in a single `eth_call` by overriding the target contract's
 /// deployed bytecode with `EphemeralStorageLens`
@@ -35,21 +32,20 @@ pub async fn get_storage_at<T, P>(
     slots: Vec<B256>,
     provider: P,
     block_id: Option<BlockId>,
-) -> Result<Vec<B256>>
+) -> Result<Vec<B256>, Error>
 where
     T: Transport + Clone,
     P: Provider<T>,
 {
     // override the deployed bytecode at `address`
-    let mut state = StateOverride::default();
-    state.insert(
+    let state = StateOverride::from([(
         address,
         AccountOverride {
             code: Some(EphemeralStorageLens::DEPLOYED_BYTECODE.clone()),
             ..Default::default()
         },
-    );
-    let lens = EphemeralStorageLensInstance::new(address, provider);
+    )]);
+    let lens = EphemeralStorageLens::new(address, provider);
     let call_builder = lens.extsload(slots).state(state);
     let call_builder = match block_id {
         Some(block_id) => call_builder.block(block_id),
@@ -63,13 +59,12 @@ mod tests {
     use super::*;
     use crate::tests::*;
     use alloy::primitives::{address, U256};
-    use anyhow::Result;
     use futures::future::join_all;
 
     const POOL_ADDRESS: Address = address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640");
 
     #[tokio::test]
-    async fn test_get_storage_at() -> Result<()> {
+    async fn test_get_storage_at() {
         let provider = PROVIDER.clone();
         let slots = get_storage_at(
             POOL_ADDRESS,
@@ -79,7 +74,8 @@ mod tests {
             provider.clone(),
             Some(BLOCK_NUMBER),
         )
-        .await?;
+        .await
+        .unwrap();
         let slots_ref = slots.as_slice();
         let provider = provider.root();
         let futures = (0..10).map(|i| async move {
@@ -91,6 +87,5 @@ mod tests {
             assert_eq!(slot, U256::from_be_bytes(slots_ref[i as usize].0));
         });
         join_all(futures).await;
-        Ok(())
     }
 }


### PR DESCRIPTION
Introduce `Error` enum for consistent error management and integrate `thiserror` for better error descriptions. Update functions to use the new error handling, replacing `anyhow::Result` with `Result<T, Error>`, and refactor tests to unwrap results for simplicity.