### PR TITLE
chore: upgrade `alloy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-lens"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "A library for querying Uniswap V3 using ephemeral lens contracts."
@@ -11,7 +11,7 @@ keywords = ["alloy", "ethereum", "solidity", "uniswap"]
 include = ["src/**/*.rs"]
 
 [dependencies]
-alloy = { version = "0.5", features = ["contract", "rpc-types"] }
+alloy = { version = "0.6", features = ["contract", "rpc-types"] }
 anyhow = "1"
 thiserror = { version = "2", default-features = false }
 
@@ -20,7 +20,7 @@ default = []
 std = ["alloy/std", "thiserror/std"]
 
 [dev-dependencies]
-alloy = { version = "0.5", features = ["transport-http"] }
+alloy = { version = "0.6", features = ["transport-http"] }
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1.20"


### PR DESCRIPTION
Bump `alloy` dependency from version 0.5 to 0.6 for both dependencies and dev-dependencies. Also, update the package version from 0.6.0 to 0.7.0 in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the package version to 0.7.0, enhancing overall functionality.
	- Upgraded the `alloy` dependency to version 0.6, ensuring improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->