### PR TITLE
chore: update alloy to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-lens"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "A library for querying Uniswap V3 using ephemeral lens contracts."
@@ -12,7 +12,7 @@ keywords = ["alloy", "ethereum", "solidity", "uniswap"]
 include = ["src/**/*.rs"]
 
 [dependencies]
-alloy = { version = "0.7", features = ["contract", "json-rpc", "rpc-types"] }
+alloy = { version = "0.8", features = ["contract", "json-rpc", "rpc-types"] }
 anyhow = "1"
 thiserror = { version = "2", default-features = false }
 
@@ -21,7 +21,7 @@ default = []
 std = ["alloy/std", "thiserror/std"]
 
 [dev-dependencies]
-alloy = { version = "0.7", features = ["transport-http"] }
+alloy = { version = "0.8", features = ["transport-http"] }
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1.20"


### PR DESCRIPTION
Upgraded alloy dependency to version 0.8 for both main and dev settings to ensure compatibility with the latest features and improvements. Incremented the package version to 0.9.0 to reflect the dependency update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 0.9.0.
	- Enhanced dependency with the latest version of `alloy` (0.8) for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->