### PR TITLE
chore: upgrade alloy and refactor transport to network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-lens"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "A library for querying Uniswap V3 using ephemeral lens contracts."
@@ -12,7 +12,7 @@ keywords = ["alloy", "ethereum", "solidity", "uniswap"]
 include = ["src/**/*.rs"]
 
 [dependencies]
-alloy = { version = "0.9", features = ["contract", "json-rpc", "rpc-types"] }
+alloy = { version = "0.11", features = ["contract", "json-rpc", "rpc-types"] }
 thiserror = { version = "2", default-features = false }
 
 [features]
@@ -20,7 +20,7 @@ default = []
 std = ["alloy/std", "thiserror/std"]
 
 [dev-dependencies]
-alloy = { version = "0.9", features = ["transport-http"] }
+alloy = { version = "0.11", features = ["transport-http"] }
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1.20"

--- a/src/pool_lens.rs
+++ b/src/pool_lens.rs
@@ -27,10 +27,11 @@ use alloc::vec::Vec;
 use alloy::{
     contract::Error as ContractError,
     eips::BlockId,
+    network::Network,
     primitives::{aliases::I24, Address},
     providers::Provider,
     sol_types::SolCall,
-    transports::{Transport, TransportError},
+    transports::TransportError,
 };
 
 /// Get the populated ticks in a tick range.
@@ -47,7 +48,7 @@ use alloy::{
 ///
 /// A vector of populated ticks within the range
 #[inline]
-pub async fn get_populated_ticks_in_range<T, P>(
+pub async fn get_populated_ticks_in_range<N, P>(
     pool: Address,
     tick_lower: I24,
     tick_upper: I24,
@@ -55,8 +56,8 @@ pub async fn get_populated_ticks_in_range<T, P>(
     block_id: Option<BlockId>,
 ) -> Result<(Vec<PopulatedTick>, I24), Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     let deploy_builder =
         EphemeralGetPopulatedTicksInRange::deploy_builder(provider, pool, tick_lower, tick_upper);
@@ -97,14 +98,14 @@ macro_rules! get_pool_storage {
 ///
 /// A vector of slots containing the storage data
 #[inline]
-pub async fn get_static_slots<T, P>(
+pub async fn get_static_slots<N, P>(
     pool: Address,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<Slot>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     get_pool_storage!(EphemeralPoolSlots::deploy_builder(provider, pool), block_id)
 }
@@ -123,7 +124,7 @@ where
 ///
 /// A vector of slots containing the storage data
 #[inline]
-pub async fn get_ticks_slots<T, P>(
+pub async fn get_ticks_slots<N, P>(
     pool: Address,
     tick_lower: I24,
     tick_upper: I24,
@@ -131,8 +132,8 @@ pub async fn get_ticks_slots<T, P>(
     block_id: Option<BlockId>,
 ) -> Result<Vec<Slot>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     get_pool_storage!(
         EphemeralPoolTicks::deploy_builder(provider, pool, tick_lower, tick_upper),
@@ -152,14 +153,14 @@ where
 ///
 /// A vector of slots containing the storage data
 #[inline]
-pub async fn get_tick_bitmap_slots<T, P>(
+pub async fn get_tick_bitmap_slots<N, P>(
     pool: Address,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<Slot>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     get_pool_storage!(
         EphemeralPoolTickBitmap::deploy_builder(provider, pool),
@@ -180,15 +181,15 @@ where
 ///
 /// A vector of slots containing the storage data
 #[inline]
-pub async fn get_positions_slots<T, P>(
+pub async fn get_positions_slots<N, P>(
     pool: Address,
     positions: Vec<PositionKey>,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<Slot>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     get_pool_storage!(
         EphemeralPoolPositions::deploy_builder(provider, pool, positions),
@@ -260,10 +261,10 @@ mod tests {
         // }
     }
 
-    async fn verify_slots<T, P>(slots: Vec<Slot>, provider: P)
+    async fn verify_slots<N, P>(slots: Vec<Slot>, provider: P)
     where
-        T: Transport + Clone,
-        P: Provider<T>,
+        N: Network,
+        P: Provider<N>,
     {
         assert!(!slots.is_empty());
         let provider = provider.root();

--- a/src/position_lens.rs
+++ b/src/position_lens.rs
@@ -24,10 +24,11 @@ use alloc::vec::Vec;
 use alloy::{
     contract::Error as ContractError,
     eips::BlockId,
+    network::Network,
     primitives::{Address, U256},
     providers::Provider,
     sol_types::SolCall,
-    transports::{Transport, TransportError},
+    transports::TransportError,
 };
 
 /// Get the details of a position given the token ID.
@@ -43,15 +44,15 @@ use alloy::{
 ///
 /// The position details
 #[inline]
-pub async fn get_position_details<T, P>(
+pub async fn get_position_details<N, P>(
     npm: Address,
     token_id: U256,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<EphemeralGetPosition::PositionState, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     let deploy_builder = EphemeralGetPosition::deploy_builder(provider, npm, token_id);
     match call_ephemeral_contract!(deploy_builder, getPositionCall, block_id) {
@@ -73,15 +74,15 @@ where
 ///
 /// The array of position details
 #[inline]
-pub async fn get_positions<T, P>(
+pub async fn get_positions<N, P>(
     npm: Address,
     token_ids: Vec<U256>,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<EphemeralGetPositions::PositionState>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     let deploy_builder = EphemeralGetPositions::deploy_builder(provider, npm, token_ids);
     match call_ephemeral_contract!(deploy_builder, getPositionsCall, block_id) {
@@ -103,15 +104,15 @@ where
 ///
 /// The array of position details
 #[inline]
-pub async fn get_all_positions_by_owner<T, P>(
+pub async fn get_all_positions_by_owner<N, P>(
     npm: Address,
     owner: Address,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<EphemeralAllPositionsByOwner::PositionState>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     let deploy_builder = EphemeralAllPositionsByOwner::deploy_builder(provider, npm, owner);
     match call_ephemeral_contract!(deploy_builder, allPositionsCall, block_id) {

--- a/src/storage_lens.rs
+++ b/src/storage_lens.rs
@@ -7,10 +7,10 @@ use crate::{bindings::ephemeralstoragelens::EphemeralStorageLens, error::Error};
 use alloc::vec::Vec;
 use alloy::{
     eips::BlockId,
+    network::Network,
     primitives::{Address, B256},
     providers::Provider,
     rpc::types::state::{AccountOverride, StateOverride},
-    transports::Transport,
 };
 
 /// Batch `eth_getStorageAt` RPC calls in a single `eth_call` by overriding the target contract's
@@ -27,15 +27,15 @@ use alloy::{
 ///
 /// The storage values at the given slots
 #[inline]
-pub async fn get_storage_at<T, P>(
+pub async fn get_storage_at<N, P>(
     address: Address,
     slots: Vec<B256>,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<B256>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     // override the deployed bytecode at `address`
     let state = StateOverride::from_iter([(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
-    providers::{ProviderBuilder, ReqwestProvider},
+    providers::{ProviderBuilder, RootProvider},
     transports::http::reqwest::Url,
 };
 use dotenv::dotenv;
@@ -11,5 +11,8 @@ pub(crate) static RPC_URL: Lazy<Url> = Lazy::new(|| {
     dotenv().ok();
     std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap()
 });
-pub(crate) static PROVIDER: Lazy<ReqwestProvider> =
-    Lazy::new(|| ProviderBuilder::new().on_http(RPC_URL.clone()));
+pub(crate) static PROVIDER: Lazy<RootProvider> = Lazy::new(|| {
+    ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .on_http(RPC_URL.clone())
+});


### PR DESCRIPTION
Updated alloy to version 0.11 and adjusted related dependencies. Refactored functions to replace `Transport` with `Network` in provider definitions for improved abstraction. Updated tests to use `RootProvider` with customized configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the package version and updated dependency versions for improved stability.
  
- **Refactor**
	- Streamlined network interactions by unifying how asynchronous operations handle connectivity, enhancing overall consistency.
  
- **Tests**
	- Enhanced the configuration of the RPC provider to improve testing reliability and request handling.

These updates refine internal behaviors, promoting a more robust and maintainable system—benefiting end-user interactions through enhanced performance and dependability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->