### PR TITLE
chore: update dependencies to alloy 0.12 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-lens"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "A library for querying Uniswap V3 using ephemeral lens contracts."
@@ -12,7 +12,7 @@ keywords = ["alloy", "ethereum", "solidity", "uniswap"]
 include = ["src/**/*.rs"]
 
 [dependencies]
-alloy = { version = "0.11", default-features = false, features = ["contract", "json-rpc", "rpc-types"] }
+alloy = { version = "0.12", default-features = false, features = ["contract", "json-rpc", "rpc-types"] }
 thiserror = { version = "2", default-features = false }
 
 [features]
@@ -20,7 +20,7 @@ default = []
 std = ["alloy/std", "thiserror/std"]
 
 [dev-dependencies]
-alloy = { version = "0.11", default-features = false, features = ["transport-http", "reqwest"] }
+alloy = { version = "0.12", default-features = false, features = ["transport-http", "reqwest"] }
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1.20"

--- a/src/position_lens.rs
+++ b/src/position_lens.rs
@@ -145,7 +145,7 @@ mod tests {
     /// Computes the address of a Uniswap V3 pool given the factory address, the two tokens, and the
     /// fee.
     ///
-    /// # Arguments
+    /// ## Arguments
     ///
     /// * `factory`: The Uniswap V3 factory address
     /// * `token_0`: The first token address

--- a/src/storage_lens.rs
+++ b/src/storage_lens.rs
@@ -16,7 +16,7 @@ use alloy::{
 /// Batch `eth_getStorageAt` RPC calls in a single `eth_call` by overriding the target contract's
 /// deployed bytecode with `EphemeralStorageLens`
 ///
-/// # Arguments
+/// ## Arguments
 ///
 /// * `address`: The contract address to fetch storage from
 /// * `slots`: The storage slots to query


### PR DESCRIPTION
Upgraded the `alloy` dependency to version 0.12 across the project. Updated the package version to 0.12.0 to reflect the dependency changes. Minor formatting adjustment to doc comments for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the package and dependency versions to ensure consistent and current builds.
- **Documentation**
  - Refined the formatting of documentation headings for enhanced clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->