### PR TITLE
refactor!: update alloy to 0.15 and use `sol!` for bindings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           version: stable
 
-      - name: Generate contract Rust bindings
-        run: yarn bind
+      - name: Compile contracts
+        run: forge build
 
       - name: Publish to crates.io
         run: cargo publish --allow-dirty

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           version: stable
 
-      - name: Generate contract Rust bindings
-        run: yarn bind
+      - name: Compile contracts
+        run: forge build
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -89,8 +89,8 @@ jobs:
         with:
           version: stable
 
-      - name: Generate contract Rust bindings
-        run: yarn bind
+      - name: Compile contracts
+        run: forge build
 
       - name: Cache Cargo registry
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-lens"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "A library for querying Uniswap V3 using ephemeral lens contracts."
@@ -9,19 +9,18 @@ readme = "README.md"
 repository = "https://github.com/shuhuiluo/uniswap-lens-rs"
 categories = ["cryptography::cryptocurrencies", "finance", "no-std"]
 keywords = ["alloy", "ethereum", "solidity", "uniswap"]
-include = ["src/**/*.rs"]
+include = ["src/**/*.rs", "out"]
 
 [dependencies]
-alloy = { version = "0.13", default-features = false, features = ["contract", "json-rpc", "rpc-types"] }
+alloy = { version = "0.15", default-features = false, features = ["contract", "json-rpc", "rpc-types"] }
 thiserror = { version = "2", default-features = false }
 
 [dev-dependencies]
-alloy = { version = "0.13", default-features = false, features = ["transport-http", "reqwest"] }
+alloy = { version = "0.15", default-features = false, features = ["transport-http", "reqwest"] }
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1.20"
 tokio = { version = "1", features = ["full"] }
-uniswap-v3-sdk = "4.3.0"
 
 [features]
 default = []

--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "bind": "forge bind --alloy -b src/bindings/ --module --overwrite",
     "build": "yarn typechain && tsc --build",
-    "clean": "tsc --build --clean && forge clean",
+    "clean": "tsc --build --clean && forge clean && hardhat clean",
     "compile": "forge build",
     "test": "forge test",
     "test:hardhat": "hardhat test",

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -4,6 +4,7 @@
 ///
 /// * `module_name` - The name of the module to create
 /// * `contract_name` - The name of the contract to bind
+#[macro_export]
 macro_rules! create_sol_binding {
     ($module_name:ident, $contract_name:ident) => {
         pub mod $module_name {
@@ -11,8 +12,7 @@ macro_rules! create_sol_binding {
                 #[sol(rpc)]
                 $contract_name,
                 concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/out/",
+                    "out/",
                     stringify!($contract_name),
                     ".sol/",
                     stringify!($contract_name),
@@ -37,10 +37,10 @@ create_sol_binding!(ephemeralgetposition, EphemeralGetPosition);
 create_sol_binding!(ephemeralgetpositions, EphemeralGetPositions);
 create_sol_binding!(ephemeralstoragelens, EphemeralStorageLens);
 
+#[cfg(test)]
 create_sol_binding!(iuniswapv3pool, IUniswapV3Pool);
+#[cfg(test)]
 create_sol_binding!(
     iuniswapv3nonfungiblepositionmanager,
     IUniswapV3NonfungiblePositionManager
 );
-create_sol_binding!(ierc20, IERC20);
-create_sol_binding!(ierc721enumerable, IERC721Enumerable);

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,0 +1,46 @@
+/// Creates a module with Solidity bindings for the specified contract.
+///
+/// ## Arguments
+///
+/// * `module_name` - The name of the module to create
+/// * `contract_name` - The name of the contract to bind
+macro_rules! create_sol_binding {
+    ($module_name:ident, $contract_name:ident) => {
+        pub mod $module_name {
+            alloy::sol!(
+                #[sol(rpc)]
+                $contract_name,
+                concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/out/",
+                    stringify!($contract_name),
+                    ".sol/",
+                    stringify!($contract_name),
+                    ".json"
+                )
+            );
+        }
+    };
+}
+
+// Use the macro to create all the bindings
+create_sol_binding!(
+    ephemeralgetpopulatedticksinrange,
+    EphemeralGetPopulatedTicksInRange
+);
+create_sol_binding!(ephemeralpoolpositions, EphemeralPoolPositions);
+create_sol_binding!(ephemeralpoolslots, EphemeralPoolSlots);
+create_sol_binding!(ephemeralpooltickbitmap, EphemeralPoolTickBitmap);
+create_sol_binding!(ephemeralpoolticks, EphemeralPoolTicks);
+create_sol_binding!(ephemeralallpositionsbyowner, EphemeralAllPositionsByOwner);
+create_sol_binding!(ephemeralgetposition, EphemeralGetPosition);
+create_sol_binding!(ephemeralgetpositions, EphemeralGetPositions);
+create_sol_binding!(ephemeralstoragelens, EphemeralStorageLens);
+
+create_sol_binding!(iuniswapv3pool, IUniswapV3Pool);
+create_sol_binding!(
+    iuniswapv3nonfungiblepositionmanager,
+    IUniswapV3NonfungiblePositionManager
+);
+create_sol_binding!(ierc20, IERC20);
+create_sol_binding!(ierc721enumerable, IERC721Enumerable);

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -9,10 +9,7 @@ macro_rules! call_ephemeral_contract {
         match deploy_builder.call_raw().await {
             Err(ContractError::TransportError(TransportError::ErrorResp(payload))) => {
                 match payload.as_revert_data() {
-                    Some(data) => Ok(<$call_type as SolCall>::abi_decode_returns(
-                        data.as_ref(),
-                        true,
-                    )?),
+                    Some(data) => Ok(<$call_type as SolCall>::abi_decode_returns(data.as_ref())?),
                     None => Err(Error::InvalidRevertData(payload)),
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 extern crate alloc;
 
-#[allow(warnings)]
 pub mod bindings;
 pub mod caller;
 pub mod error;

--- a/src/pool_lens.rs
+++ b/src/pool_lens.rs
@@ -13,9 +13,7 @@ use crate::{
         },
         ephemeralpoolpositions::{EphemeralPoolPositions, PoolUtils::PositionKey},
         ephemeralpoolslots::{
-            EphemeralPoolSlots,
-            EphemeralPoolSlots::{getSlotsCall, getSlotsReturn},
-            PoolUtils::Slot,
+            EphemeralPoolSlots, EphemeralPoolSlots::getSlotsCall, PoolUtils::Slot,
         },
         ephemeralpooltickbitmap::EphemeralPoolTickBitmap,
         ephemeralpoolticks::EphemeralPoolTicks,
@@ -79,10 +77,7 @@ where
 /// Call an ephemeral contract and return the decoded storage slots
 macro_rules! get_pool_storage {
     ($deploy_builder:expr, $block_id:expr) => {
-        match call_ephemeral_contract!($deploy_builder, getSlotsCall, $block_id) {
-            Ok(getSlotsReturn { slots }) => Ok(slots),
-            Err(err) => Err(err.into()),
-        }
+        call_ephemeral_contract!($deploy_builder, getSlotsCall, $block_id)
     };
 }
 
@@ -216,13 +211,7 @@ mod tests {
         let provider = PROVIDER.clone();
         let pool = IUniswapV3Pool::new(POOL_ADDRESS, provider.clone());
         let tick_current = pool.slot0().block(BLOCK_NUMBER).call().await.unwrap().tick;
-        let tick_spacing = pool
-            .tickSpacing()
-            .block(BLOCK_NUMBER)
-            .call()
-            .await
-            .unwrap()
-            ._0;
+        let tick_spacing = pool.tickSpacing().block(BLOCK_NUMBER).call().await.unwrap();
         let (ticks, _) = get_populated_ticks_in_range(
             POOL_ADDRESS,
             tick_current,
@@ -313,14 +302,14 @@ mod tests {
         let provider = PROVIDER.clone();
         // create a filter to get the mint events
         let filter = Filter::new()
-            .from_block(BLOCK_NUMBER.as_u64().unwrap() - 10000)
+            .from_block(BLOCK_NUMBER.as_u64().unwrap() - 499)
             .to_block(BLOCK_NUMBER.as_u64().unwrap())
             .event_signature(<Mint as SolEvent>::SIGNATURE_HASH);
         let logs = provider.get_logs(&filter).await.unwrap();
         // decode the logs into position keys
         let positions: Vec<_> = logs
             .iter()
-            .map(|log| <Mint as SolEvent>::decode_log_data(log.data(), true).unwrap())
+            .map(|log| <Mint as SolEvent>::decode_log_data(log.data()).unwrap())
             .map(
                 |Mint {
                      owner,

--- a/src/storage_lens.rs
+++ b/src/storage_lens.rs
@@ -51,7 +51,7 @@ where
         Some(block_id) => call_builder.block(block_id),
         None => call_builder,
     };
-    Ok(call_builder.call().await?._0)
+    Ok(call_builder.call().await?)
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,5 +14,5 @@ pub(crate) static RPC_URL: Lazy<Url> = Lazy::new(|| {
 pub(crate) static PROVIDER: Lazy<RootProvider> = Lazy::new(|| {
     ProviderBuilder::new()
         .disable_recommended_fillers()
-        .on_http(RPC_URL.clone())
+        .connect_http(RPC_URL.clone())
 });


### PR DESCRIPTION
- Upgraded the `alloy` dependency to version 0.15.
- Replaced explicit Solidity bindings with the `sol!` macro for cleaner and more efficient code.
- Adjusted related implementations and tests accordingly.

Closes #25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a macro to generate Solidity contract bindings as Rust modules, providing easier access to various contract interfaces.

- **Dependency Updates**
  - Upgraded the "alloy" dependency to version 0.15.
  - Removed the "uniswap-v3-sdk" development dependency.

- **Build & Workflow**
  - Updated build scripts and GitHub Actions workflows to use the Foundry toolchain (`forge build`) for contract compilation.
  - Adjusted package scripts for improved cleaning and removed an obsolete script.

- **Improvements**
  - Simplified and unified code structure, error handling, and test utilities for better maintainability and readability.
  - Enhanced test setup and fixed type handling in tests.

- **Version**
  - Bumped package version to 0.14.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->