### PR TITLE
chore: bump alloy to 1.0.1 and expand bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-lens"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "A library for querying Uniswap V3 using ephemeral lens contracts."
@@ -8,15 +8,31 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/shuhuiluo/uniswap-lens-rs"
 categories = ["cryptography::cryptocurrencies", "finance", "no-std"]
-keywords = ["alloy", "ethereum", "solidity", "uniswap"]
-include = ["src/**/*.rs", "out"]
+keywords = ["alloy", "ethereum", "lens", "solidity", "uniswap"]
+include = [
+    "src/**/*.rs",
+    "out/EphemeralAllPositionsByOwner.sol",
+    "out/EphemeralGetPopulatedTicksInRange.sol",
+    "out/EphemeralGetPosition.sol",
+    "out/EphemeralGetPositions.sol",
+    "out/EphemeralPoolPositions.sol",
+    "out/EphemeralPoolSlots.sol",
+    "out/EphemeralPoolTickBitmap.sol",
+    "out/EphemeralPoolTicks.sol",
+    "out/EphemeralStorageLens.sol",
+    "out/IUniswapV3Pool.sol",
+    "out/IUniswapV3NonfungiblePositionManager.sol",
+    "out/IERC20.sol",
+    "out/IERC20Metadata.sol",
+    "out/IERC721Enumerable.sol"
+]
 
 [dependencies]
-alloy = { version = "0.15", default-features = false, features = ["contract", "json-rpc", "rpc-types"] }
+alloy = { version = "1.0.1", default-features = false, features = ["contract", "json-rpc", "rpc-types"] }
 thiserror = { version = "2", default-features = false }
 
 [dev-dependencies]
-alloy = { version = "0.15", default-features = false, features = ["transport-http", "reqwest"] }
+alloy = { version = "1.0.1", default-features = false, features = ["transport-http", "reqwest"] }
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1.20"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -4,7 +4,6 @@
 ///
 /// * `module_name` - The name of the module to create
 /// * `contract_name` - The name of the contract to bind
-#[macro_export]
 macro_rules! create_sol_binding {
     ($module_name:ident, $contract_name:ident) => {
         pub mod $module_name {
@@ -24,23 +23,25 @@ macro_rules! create_sol_binding {
 }
 
 // Use the macro to create all the bindings
+create_sol_binding!(ephemeralallpositionsbyowner, EphemeralAllPositionsByOwner);
 create_sol_binding!(
     ephemeralgetpopulatedticksinrange,
     EphemeralGetPopulatedTicksInRange
 );
+create_sol_binding!(ephemeralgetposition, EphemeralGetPosition);
+create_sol_binding!(ephemeralgetpositions, EphemeralGetPositions);
 create_sol_binding!(ephemeralpoolpositions, EphemeralPoolPositions);
 create_sol_binding!(ephemeralpoolslots, EphemeralPoolSlots);
 create_sol_binding!(ephemeralpooltickbitmap, EphemeralPoolTickBitmap);
 create_sol_binding!(ephemeralpoolticks, EphemeralPoolTicks);
-create_sol_binding!(ephemeralallpositionsbyowner, EphemeralAllPositionsByOwner);
-create_sol_binding!(ephemeralgetposition, EphemeralGetPosition);
-create_sol_binding!(ephemeralgetpositions, EphemeralGetPositions);
 create_sol_binding!(ephemeralstoragelens, EphemeralStorageLens);
 
-#[cfg(test)]
 create_sol_binding!(iuniswapv3pool, IUniswapV3Pool);
-#[cfg(test)]
 create_sol_binding!(
     iuniswapv3nonfungiblepositionmanager,
     IUniswapV3NonfungiblePositionManager
 );
+
+create_sol_binding!(ierc20, IERC20);
+create_sol_binding!(ierc20metadata, IERC20Metadata);
+create_sol_binding!(ierc721enumerable, IERC721Enumerable);


### PR DESCRIPTION
Updated alloy dependency to version 1.0.1 and added new contract bindings to support additional Uniswap functionalities. Updated Cargo.toml to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for standard token interfaces, including ERC20, ERC20Metadata, and ERC721Enumerable.
- **Improvements**
  - Expanded and reorganized the set of available contract bindings for enhanced Solidity compatibility.
  - Updated package metadata and keywords for improved discoverability.
- **Dependency Updates**
  - Upgraded the "alloy" dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->